### PR TITLE
Separate shortcodes for individual data tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The plugin is activated by the shortcode \[stars-at-night\]. Here is an example:
 * **timezone** : A recognizable timezeone. For a list of valid values, see http://php.net/manual/en/timezones.php. 
 * **days** : The number of days to predict. Must be a value from 1-10. Default is 3 days.
 
+You can also display the individual data tables via more specific shortcodes:
+
+\[stars-at-night-sun-moon name=\"Mount Kilimanjaro\" lat=-2.55 long=37.55 timezone=Africa/EAT\]
+\[stars-at-night-planets name=\"Ushuaia\" lat=-54.8 long=-68.33 timezone=America/Argentina/Ushuaia\]
+\[stars-at-night-iss name=\"Mount Burnett Observatory\" lat=-37.9 long=145.4 timezone=Australia/Melbourne days=7\]
+
 # Credits
 
 * Lunar images by Dan Morgan (dan@danmorgan.org). Used with permission. http://DanMorgan.org.

--- a/src/class-stars-at-night-manager.php
+++ b/src/class-stars-at-night-manager.php
@@ -103,8 +103,10 @@ class Stars_At_Night_Manager {
      * WordPress shortcodes for this plugin
      */
     public function register_shortcodes() {
-        add_shortcode ( 'stars-at-night', array ($this,'run_stars_at_night' 
-        ) );
+        add_shortcode ( 'stars-at-night',          array ($this,'run_stars_at_night') );
+        add_shortcode ( 'stars-at-night-sun-moon', array ($this,'run_stars_at_night') );
+        add_shortcode ( 'stars-at-night-planets',  array ($this,'run_stars_at_night') );
+        add_shortcode ( 'stars-at-night-iss',      array ($this,'run_stars_at_night') );
     }
 
     /**
@@ -133,8 +135,14 @@ class Stars_At_Night_Manager {
      *
      *            graphical=not used at present. Will cause an image of the Moon phase to be
      *            displayed.
+     *
+     * @param content String
+     *            The shortcode content or null.
+     * @param shortcode_tag String
+     *            The shortcode tag.
+     *
      */
-    public function run_stars_at_night($atts) {
+    public function run_stars_at_night($atts, $content, $shortcode_tag) {
         if (! defined ( 'WPINC' )) {
             die ();
         }
@@ -174,14 +182,29 @@ class Stars_At_Night_Manager {
         // error_log ( 'startdate ' . $this->startDate->format ( 'm/d/Y' ) );
         $this->endDate = new DateTime ( $today->format ( 'm/d/Y' ) );
         $this->endDate->add ( new DateInterval ( 'P' . ($this->sanitized_days - 1) . 'D' ) );
-        // error_log ( 'enddate ' . $this->endDate->format ( 'm/d/Y' ) );
-        // get the tables
-        $sunAndMoonTable = $this->getSunAndMoonTable ();
-        // $issTable = $this->getISSTable ();
-        // $iridiumTable = $this->getIridiumTable ();
-        $planetTable = $this->getPlanetTable ();
-        
-        return $sunAndMoonTable . "<p>" . $planetTable . "<p>"; // . $issTable . "<p>" . $iridiumTable;
+
+        // Create an output string.
+        $output = '';
+
+        // Populate the output depending on the shortcode tag.
+        switch ($shortcode_tag) {
+          case 'stars-at-night-sun-moon':
+            $output .= '<p>' . $this->getSunAndMoonTable ();
+            break;
+          case 'stars-at-night-planets':
+            $output .= '<p>' . $this->getPlanetTable ();
+            break;
+          case 'stars-at-night-iss':
+            $output .= '<p>'.  $this->getISSTable ();
+            break;
+          default:
+            $output .= '<p>' . $this->getSunAndMoonTable ();
+            $output .= '<p>' . $this->getPlanetTable ();
+            $output .= '<p>'.  $this->getISSTable ();
+            break;
+        }
+
+        return $output;
     }
 
     /**


### PR DESCRIPTION
Add three new short-codes (and document them) to allow data tables to be added separately.

Although this change does not affect the output of the original shortcode, I've had issues with the stand-alone planet data table when it is embedded on a page after the sun/moon one. On a page by itself it seems to work fine.